### PR TITLE
Change packages naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-sardana-green.svg)](https://anaconda.org/conda-forge/sardana) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sardana.svg)](https://anaconda.org/conda-forge/sardana) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sardana.svg)](https://anaconda.org/conda-forge/sardana) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sardana.svg)](https://anaconda.org/conda-forge/sardana) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-sardana--client-green.svg)](https://anaconda.org/conda-forge/sardana-client) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sardana-client.svg)](https://anaconda.org/conda-forge/sardana-client) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sardana-client.svg)](https://anaconda.org/conda-forge/sardana-client) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sardana-client.svg)](https://anaconda.org/conda-forge/sardana-client) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-sardana--config-green.svg)](https://anaconda.org/conda-forge/sardana-config) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sardana-config.svg)](https://anaconda.org/conda-forge/sardana-config) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sardana-config.svg)](https://anaconda.org/conda-forge/sardana-config) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sardana-config.svg)](https://anaconda.org/conda-forge/sardana-config) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-sardana--server-green.svg)](https://anaconda.org/conda-forge/sardana-server) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sardana-server.svg)](https://anaconda.org/conda-forge/sardana-server) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sardana-server.svg)](https://anaconda.org/conda-forge/sardana-server) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sardana-server.svg)](https://anaconda.org/conda-forge/sardana-server) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sardana--core-green.svg)](https://anaconda.org/conda-forge/sardana-core) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sardana-core.svg)](https://anaconda.org/conda-forge/sardana-core) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sardana-core.svg)](https://anaconda.org/conda-forge/sardana-core) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sardana-core.svg)](https://anaconda.org/conda-forge/sardana-core) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-sardana--qt-green.svg)](https://anaconda.org/conda-forge/sardana-qt) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sardana-qt.svg)](https://anaconda.org/conda-forge/sardana-qt) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sardana-qt.svg)](https://anaconda.org/conda-forge/sardana-qt) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sardana-qt.svg)](https://anaconda.org/conda-forge/sardana-qt) |
 
 Installing sardana
 ==================
@@ -55,16 +55,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `sardana, sardana-client, sardana-config, sardana-server` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `sardana, sardana-config, sardana-core, sardana-qt` can be installed with `conda`:
 
 ```
-conda install sardana sardana-client sardana-config sardana-server
+conda install sardana sardana-config sardana-core sardana-qt
 ```
 
 or with `mamba`:
 
 ```
-mamba install sardana sardana-client sardana-config sardana-server
+mamba install sardana sardana-config sardana-core sardana-qt
 ```
 
 It is possible to list all of the versions of `sardana` available on your platform with `conda`:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,8 @@ requirements:
     - pip
     - python >=3.5
   run:
-    - {{ pin_subpackage('sardana-server', exact=True) }}
-    - {{ pin_subpackage('sardana-client', exact=True) }}
+    - {{ pin_subpackage('sardana-core', exact=True) }}
+    - {{ pin_subpackage('sardana-qt', exact=True) }}
 
 test:
   commands:
@@ -29,7 +29,7 @@ test:
     - pip
 
 outputs:
-  - name: sardana-server
+  - name: sardana-core
     script: build_core.sh
     build:
       noarch: python
@@ -52,6 +52,7 @@ outputs:
         - python >=3.5
       run:
         - click
+        - itango >=0.1.6
         - lxml >=2.3
         - pytango >=9.2.5
         - python >=3.5
@@ -67,16 +68,15 @@ outputs:
         - Sardana --help
         - sardana --help
 
-  - name: sardana-client
+  - name: sardana-qt
     build:
       noarch: python
     requirements:
       host:
         - python >=3.5
       run:
-        - {{ pin_subpackage('sardana-server', exact=True) }}
+        - {{ pin_subpackage('sardana-core', exact=True) }}
         - taurus-qt >=5.0.0
-        - itango >=0.1.6
     test:
       imports:
         - sardana.spock
@@ -91,10 +91,7 @@ outputs:
       host:
         - python >=3.5
       run:
-        - {{ pin_subpackage('sardana-server', exact=True) }}
-        # itango is needed here otherwise no subcommand can be added to "sardana"
-        # as it's part of the requirements
-        - itango >=0.1.6
+        - {{ pin_subpackage('sardana-core', exact=True) }}
         - dsconfig >=1.6.7
         - pyyaml
         - ruamel.yaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 88b282f8fbaf87dd6182c5654dbd35e06b0a64968c671e3d61bd7171921b88ab
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   run:
     - {{ pin_subpackage('sardana-core', exact=True) }}
     - {{ pin_subpackage('sardana-qt', exact=True) }}
+    - {{ pin_subpackage('sardana-config', exact=True) }}
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

Following the comments on https://github.com/conda-forge/sardana-feedstock/pull/19, this is a proposal for updating the packages name:

- sardana-core: core packages with all sardana required dependencies but no qt (taurus-core only) - this includes `itango` as it's a required dependency
- sardana-qt: sardana-core + taurus-qt
- sardana-config: sardana-core + config dependencies
- sardana: sardana-core + sardana-qt + sardana-config

~~Propose to not include `sardana-config` in `sardana` for now as those dependencies are still optional for the pypi package.~~

This will allow us to run the following command to install only the required dependencies (no qt): `conda install --only-deps sardana-core` or with qt: `conda install --only-deps sardana-core taurus-qt`


