### PR TITLE
Fix entry points

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3ea6d13ca8c642bafa602c61a018ea52ac1c826a3c4f54e420eeada24d274704
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,10 +43,10 @@ outputs:
         - spock = sardana.spock:main
         - diffractometeralignment = sardana.taurus.qt.qtgui.extra_hkl.diffractometeralignment:main
         - hklscan = sardana.taurus.qt.qtgui.extra_hkl.hklscan:main
-        - macroexecutor = sardana.taurus.qt.qtgui.extra_macroexecutor.macroexecutor:main
-        - sequencer = sardana.taurus.qt.qtgui.extra_macroexecutor.sequenceeditor:main
+        - macroexecutor = sardana.taurus.qt.qtgui.extra_macroexecutor.macroexecutor:_main
+        - sequencer = sardana.taurus.qt.qtgui.extra_macroexecutor.sequenceeditor:_main
         - ubmatrix = sardana.taurus.qt.qtgui.extra_hkl.ubmatrix:main
-        - showscan = sardana.taurus.qt.qtgui.extra_sardana.showscanonline:main
+        - showscan = sardana.taurus.qt.qtgui.extra_sardana.showscanonline:_main
     requirements:
       host:
         - pip


### PR DESCRIPTION
From version 3.4.0 the entry point for sequener, macroexecutor and showscan changed on the setup.py. The sequencer is the only which fail, but the other use the wrong code. 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
